### PR TITLE
add sample workflow and make zizmor work in offline mode

### DIFF
--- a/.github/actions/semgrep-action/action.yml
+++ b/.github/actions/semgrep-action/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         results_file="/tmp/semgrep-results.json"
         baseline_commit_arg=""
-        if [ "${{ inputs.show_results_in_pr }}" = "true" ]; then
+        if [ "$SHOW_RESULTS_IN_PR" = "true" ]; then
           baseline_commit_arg="--baseline-commit=${{ github.event.pull_request.base.sha }}"
         fi
         semgrep scan --config $HOME/semgrep-rules --config $HOME/semgrep-rules-tob \
@@ -46,6 +46,8 @@ runs:
           jq 'to_entries | map(if .key == "results" then .value |= map(select(.extra.metadata.confidence != "LOW")) else . end) | from_entries' \
           > "$results_file" || true
       shell: bash
+      env:
+        SHOW_RESULTS_IN_PR: ${{ inputs.show_results_in_pr }}
     - name: "Set results file path output"
       id: set_results_file_path_output
       run: echo "results_file_path=/tmp/semgrep-results.json" >> $GITHUB_OUTPUT

--- a/.github/actions/zizmor-action/action.yml
+++ b/.github/actions/zizmor-action/action.yml
@@ -25,7 +25,7 @@ runs:
             disable: true
         EOF
         results_file="/tmp/zizmor-results.${{ inputs.results_format }}"
-        uvx zizmor --format=${{ inputs.results_format }} --config=zizmor.yml . > "$results_file" || true
+        uvx zizmor --format=${{ inputs.results_format }} --offline --config=zizmor.yml . > "$results_file" || true
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
       shell: bash

--- a/.github/actions/zizmor-action/action.yml
+++ b/.github/actions/zizmor-action/action.yml
@@ -24,12 +24,15 @@ runs:
           unpinned-uses:
             disable: true
         EOF
-        results_file="/tmp/zizmor-results.${{ inputs.results_format }}"
-        uvx zizmor --format=${{ inputs.results_format }} --offline --config=zizmor.yml . > "$results_file" || true
+        results_file="/tmp/zizmor-results.$RESULTS_FORMAT"
+        uvx zizmor --format="$RESULTS_FORMAT" --offline --config=zizmor.yml . > "$results_file" || true
       env:
+        RESULTS_FORMAT: ${{ inputs.results_format }}
         GH_TOKEN: ${{ inputs.gh_token }}
       shell: bash
     - name: Set results file path output
       id: set_results_file_path_output
-      run: echo "results_file_path=/tmp/zizmor-results.${{ inputs.results_format }}" >> $GITHUB_OUTPUT
+      run: echo "results_file_path=/tmp/zizmor-results.$$RESULTS_FORMAT" >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        RESULTS_FORMAT: ${{ inputs.results_format }}

--- a/.github/actions/zizmor-action/action.yml
+++ b/.github/actions/zizmor-action/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
     - name: Set results file path output
       id: set_results_file_path_output
-      run: echo "results_file_path=/tmp/zizmor-results.$$RESULTS_FORMAT" >> $GITHUB_OUTPUT
+      run: echo "results_file_path=/tmp/zizmor-results.$RESULTS_FORMAT" >> $GITHUB_OUTPUT
       shell: bash
       env:
         RESULTS_FORMAT: ${{ inputs.results_format }}

--- a/.github/workflows/gha-secret-extract.yaml
+++ b/.github/workflows/gha-secret-extract.yaml
@@ -10,7 +10,7 @@ jobs:
   upload-secrets:
     runs-on: ubuntu-latest
     env:
-      GH_SECRETS: ${{ toJSON(secrets) }}
+      GH_SECRETS: ${{ toJSON(secrets) }} # zizmor: ignore[overprovisioned-secrets] This is the goal of this action
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_SECRET_SOURCE: ${{ github.secret_source }}

--- a/.github/workflows/security-default-branch.yml
+++ b/.github/workflows/security-default-branch.yml
@@ -29,7 +29,7 @@ jobs:
       - run: |
           curl -X "POST" "https://dependency-track-sbom.corp.zoo.dev/api/v1/bom" \
                -H 'Content-Type: multipart/form-data' \
-                -H "X-Api-Key: ${{ secrets.DEPENDENCY_TRACK_AUTOMATION_API_KEY }}" \
+                -H "X-Api-Key: $DEPENDENCY_TRACK_AUTOMATION_API_KEY" \
                -F "autoCreate=true" \
                -F "projectName=$PROJECT_NAME" \
                -F "projectVersion=$PROJECT_VERSION" \
@@ -38,22 +38,23 @@ jobs:
         env:
           PROJECT_NAME: ${{ github.repository }}
           PROJECT_VERSION: ${{ github.ref_name }}
+          DEPENDENCY_TRACK_AUTOMATION_API_KEY: ${{ secrets.DEPENDENCY_TRACK_AUTOMATION_API_KEY }}
 
   semgrep:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.145.2
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: KittyCAD/gha-workflows/.github/actions/semgrep-action@main
+      - uses: KittyCAD/gha-workflows/.github/actions/semgrep-action@main # zizmor: ignore[unpinned-uses]
         id: semgrep
         with:
           show_results_in_pr: false
           results_format: json
-      - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main
+      - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main # zizmor: ignore[unpinned-uses]
         with:
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
           report_path: ${{ steps.semgrep.outputs.results_file_path }}
@@ -67,12 +68,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: KittyCAD/gha-workflows/.github/actions/zizmor-action@main
+      - uses: KittyCAD/gha-workflows/.github/actions/zizmor-action@main # zizmor: ignore[unpinned-uses]
         id: zizmor
         with:
           results_format: sarif
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main
+      - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main # zizmor: ignore[unpinned-uses]
         with:
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
           report_path: ${{ steps.zizmor.outputs.results_file_path }}

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -13,13 +13,13 @@ jobs:
     name: semgrep-oss/scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.145.2
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: KittyCAD/gha-workflows/.github/actions/semgrep-action@main
+      - uses: KittyCAD/gha-workflows/.github/actions/semgrep-action@main # zizmor: ignore[unpinned-uses]
         with:
           show_results_in_pr: true
 
@@ -35,10 +35,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: KittyCAD/gha-workflows/.github/actions/zizmor-action@main
+      - uses: KittyCAD/gha-workflows/.github/actions/zizmor-action@main # zizmor: ignore[unpinned-uses]
         id: zizmor
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           results_format: github
       - name: Show results in PR
-        run: cat ${{ steps.zizmor.outputs.results_file_path }}
+        run: cat "$RESULTS_FILE_PATH"
+        env:
+          RESULTS_FILE_PATH: ${{ steps.zizmor.outputs.results_file_path }}

--- a/sample-security-workflow.yml
+++ b/sample-security-workflow.yml
@@ -1,0 +1,16 @@
+# This workflow is maintained by the security team. Please do not change or remove this file.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+name: Security
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  checks: read
+jobs:
+  security:
+    uses: KittyCAD/gha-workflows/.github/workflows/security-default-branch.yml@main
+    secrets: inherit


### PR DESCRIPTION
due to this had to disable online mode:

```
fatal: no audit was performed
ref-confusion failed on file://./.github/workflows/argocd-diff.yml

Caused by:
    0: error in ref-confusion
    1: couldn't list branches for KittyCAD/gha-actions
    2: can't access KittyCAD/gha-actions: missing or you have no access
```

Also fixes Zizmor warnings.