### PR TITLE
Retain security reports before DefectDojo uploads

### DIFF
--- a/.github/workflows/security-default-branch.yml
+++ b/.github/workflows/security-default-branch.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           show_results_in_pr: false
           results_format: json
+      - name: Retain Semgrep report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-results-${{ github.run_attempt }}
+          path: ${{ steps.semgrep.outputs.results_file_path }}
+          if-no-files-found: error
+          retention-days: 30
       - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main # zizmor: ignore[unpinned-uses]
         with:
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
@@ -73,10 +80,16 @@ jobs:
         with:
           results_format: sarif
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Retain Zizmor report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zizmor-results-${{ github.run_attempt }}
+          path: ${{ steps.zizmor.outputs.results_file_path }}
+          if-no-files-found: error
+          retention-days: 30
       - uses: KittyCAD/gha-workflows/.github/actions/upload-defectdojo@main # zizmor: ignore[unpinned-uses]
         with:
           dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
           report_path: ${{ steps.zizmor.outputs.results_file_path }}
           scan_type: SARIF
           engagement: Zizmor
-


### PR DESCRIPTION
## Summary

- retain Semgrep JSON and Zizmor SARIF reports before uploading them to DefectDojo
- keep each workflow attempt under a distinct artifact name for 30 days
- pin `actions/upload-artifact` to v7.0.1

When DefectDojo rejected the organization token, the scanners completed but their reports were discarded with the runner. Retaining the reports first keeps an outage recoverable.

Closes KittyCAD/ciso#341.

## Verification

- Reran the exact failed CISO Security workflow after rotating `DEFECTDOJO_API_TOKEN`: [run 32413418077, attempt 2](https://github.com/KittyCAD/ciso/actions/runs/32413418077) completed successfully. DefectDojo accepted Semgrep test 189 and Zizmor test 383.
- Reran the representative production workflow: [modeling-app run 32688574208, attempt 2](https://github.com/KittyCAD/modeling-app/actions/runs/32688574208) completed successfully. DefectDojo accepted Semgrep test 186 and Zizmor test 187.
- Ran this branch through the reusable workflow: [run 32773258349](https://github.com/KittyCAD/ciso/actions/runs/32773258349) completed all three jobs successfully, including both artifact-retention and DefectDojo-upload steps.
- Downloaded `semgrep-results-1` and `zizmor-results-1` from that run and validated their JSON and SARIF structures with `jq`. Both expire after 30 days as configured.
- Parsed every workflow and action YAML file with Ruby Psych.
- Ran `uvx zizmor --format=plain .`; the seven findings are existing unpinned `checkout`/`setup-python` references, and this change introduces none.
- Independent adversarial review found no actionable issues.